### PR TITLE
Enhance clarinet builder with alternate fingering optimisation

### DIFF
--- a/server/openwind_service/fingerings_bb.py
+++ b/server/openwind_service/fingerings_bb.py
@@ -1,89 +1,219 @@
-"""Standard Bb clarinet fingering utilities."""
+"""Standard Bb clarinet fingering utilities with alternate variants."""
 
 from __future__ import annotations
 
 from typing import Dict, Iterable, List, Sequence
 
-from .models import Geometry, ToneHole
+from .models import ToneHole
 
-# The fingering template is defined from the mouthpiece (index 0) to the bell (last).
-# 0 -> closed, 1 -> open. Half-hole fingerings use 0.5.
-FINGERING_TEMPLATE: List[Dict[str, object]] = [
-    {"note": "C3", "midi": 48, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "C#3", "midi": 49, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
-    {"note": "D3", "midi": 50, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]},
-    {"note": "Eb3", "midi": 51, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]},
-    {"note": "E3", "midi": 52, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]},
-    {"note": "F3", "midi": 53, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]},
-    {"note": "F#3", "midi": 54, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]},
-    {"note": "G3", "midi": 55, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "Ab3", "midi": 56, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "A3", "midi": 57, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "Bb3", "midi": 58, "holes": [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "B3", "midi": 59, "holes": [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "C4", "midi": 60, "holes": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "C#4", "midi": 61, "holes": [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "D4", "midi": 62, "holes": [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "Eb4", "midi": 63, "holes": [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "E4", "midi": 64, "holes": [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "F4", "midi": 65, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-    {"note": "F#4", "midi": 66, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.5]},
-    {"note": "G4", "midi": 67, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]},
-    {"note": "Ab4", "midi": 68, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]},
-    {"note": "A4", "midi": 69, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]},
-    {"note": "Bb4", "midi": 70, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]},
-    {"note": "B4", "midi": 71, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]},
-    {"note": "C5", "midi": 72, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "C#5", "midi": 73, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "D5", "midi": 74, "holes": [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "Eb5", "midi": 75, "holes": [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "E5", "midi": 76, "holes": [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "F5", "midi": 77, "holes": [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "F#5", "midi": 78, "holes": [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "G5", "midi": 79, "holes": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "Ab5", "midi": 80, "holes": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "A5", "midi": 81, "holes": [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "Bb5", "midi": 82, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "B5", "midi": 83, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"note": "C6", "midi": 84, "holes": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
+
+def _normalise_state(value: object) -> float:
+    """Convert fingering state objects to ``float`` values."""
+
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 1.0 if value else 0.0
+
+
+def _first_open_index(holes: Sequence[object]) -> int | None:
+    for idx, value in enumerate(holes):
+        if _normalise_state(value) >= 0.5:
+            return idx
+    return None
+
+
+def _previous_closed_index(holes: Sequence[object], start: int) -> int | None:
+    for idx in range(start - 1, -1, -1):
+        if _normalise_state(holes[idx]) < 0.5:
+            return idx
+    return None
+
+
+def _next_closed_index(holes: Sequence[object], start: int) -> int | None:
+    for idx in range(start + 1, len(holes)):
+        if _normalise_state(holes[idx]) < 0.5:
+            return idx
+    return None
+
+
+def _make_entry(note: str, midi: int, holes: Sequence[object], variant: str = "standard") -> Dict[str, object]:
+    label = note if variant == "standard" else f"{note} ({variant})"
+    return {
+        "note": note,
+        "midi": midi,
+        "holes": list(holes),
+        "variant": variant,
+        "label": label,
+    }
+
+
+__FRENCH_STANDARD: List[Dict[str, object]] = [
+    _make_entry("C3", 48, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("C#3", 49, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    _make_entry("D3", 50, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]),
+    _make_entry("Eb3", 51, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]),
+    _make_entry("E3", 52, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]),
+    _make_entry("F3", 53, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]),
+    _make_entry("F#3", 54, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]),
+    _make_entry("G3", 55, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("Ab3", 56, [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("A3", 57, [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("Bb3", 58, [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("B3", 59, [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("C4", 60, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("C#4", 61, [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("D4", 62, [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("Eb4", 63, [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("E4", 64, [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("F4", 65, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    _make_entry("F#4", 66, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.5]),
+    _make_entry("G4", 67, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]),
+    _make_entry("Ab4", 68, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]),
+    _make_entry("A4", 69, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]),
+    _make_entry("Bb4", 70, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]),
+    _make_entry("B4", 71, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]),
+    _make_entry("C5", 72, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("C#5", 73, [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("D5", 74, [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("Eb5", 75, [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("E5", 76, [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("F5", 77, [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("F#5", 78, [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("G5", 79, [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("Ab5", 80, [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("A5", 81, [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("Bb5", 82, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("B5", 83, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    _make_entry("C6", 84, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
 ]
 
 
-DEFAULT_NOTES: List[str] = [entry["note"] for entry in FINGERING_TEMPLATE]
+def _auto_variants(holes: Sequence[object]) -> List[tuple[str, List[object]]]:
+    first_open = _first_open_index(holes)
+    variants: List[tuple[str, List[object]]] = []
+
+    if first_open is None:
+        shaded = list(holes)
+        shaded[-1] = 0.5
+        variants.append(("bell-vent", shaded))
+
+        register = list(holes)
+        register[-2] = 0.5
+        variants.append(("register-vent", register))
+        return variants
+
+    prev_idx = _previous_closed_index(holes, first_open)
+    if prev_idx is not None:
+        shaded = list(holes)
+        shaded[prev_idx] = 0.5
+        variants.append(("half-vent", shaded))
+
+    next_idx = _next_closed_index(holes, first_open)
+    if next_idx is not None:
+        extended = list(holes)
+        extended[next_idx] = 1
+        variants.append(("long", extended))
+    else:
+        resonant = list(holes)
+        resonant[-1] = 0.5
+        variants.append(("resonance", resonant))
+
+    if first_open > 0:
+        shade = list(holes)
+        shade[first_open - 1] = 0.5
+        variants.append(("ring-shade", shade))
+
+    unique: List[tuple[str, List[object]]] = []
+    seen = {tuple(_normalise_state(v) for v in holes)}
+    for name, variant in variants:
+        key = tuple(_normalise_state(v) for v in variant)
+        if key not in seen:
+            unique.append((name, variant))
+            seen.add(key)
+    return unique
+
+
+def _build_template() -> List[Dict[str, object]]:
+    template: List[Dict[str, object]] = []
+    for entry in __FRENCH_STANDARD:
+        template.append(entry)
+        for name, variant in _auto_variants(entry["holes"]):
+            template.append(
+                _make_entry(
+                    entry["note"],
+                    int(entry["midi"]),
+                    variant,
+                    variant=name,
+                )
+            )
+    return template
+
+
+FINGERING_TEMPLATE: List[Dict[str, object]] = _build_template()
+_DEFAULT_BY_NOTE: Dict[str, List[Dict[str, object]]] = {}
+_DEFAULT_BY_LABEL: Dict[str, Dict[str, object]] = {}
+for entry in FINGERING_TEMPLATE:
+    _DEFAULT_BY_LABEL[entry["label"]] = entry
+    _DEFAULT_BY_NOTE.setdefault(entry["note"], []).append(entry)
+
+DEFAULT_NOTES: List[str] = [entry["label"] for entry in FINGERING_TEMPLATE]
+
+
+def _resolve_notes(notes: Iterable[str] | None) -> List[Dict[str, object]]:
+    if notes is None:
+        return list(FINGERING_TEMPLATE)
+
+    resolved: List[Dict[str, object]] = []
+    seen: set[str] = set()
+    for item in notes:
+        token = str(item)
+        if token in _DEFAULT_BY_LABEL:
+            entry = _DEFAULT_BY_LABEL[token]
+            if entry["label"] not in seen:
+                resolved.append(entry)
+                seen.add(entry["label"])
+            continue
+
+        for entry in _DEFAULT_BY_NOTE.get(token, []):
+            if entry["label"] not in seen:
+                resolved.append(entry)
+                seen.add(entry["label"])
+    if not resolved:
+        return list(FINGERING_TEMPLATE)
+    return resolved
 
 
 def build_fingering_chart(holes: Sequence[ToneHole], notes: Iterable[str] | None = None) -> List[List[object]]:
     """Create a fingering chart list compatible with :class:`InstrumentGeometry`."""
 
-    if notes is None:
-        notes = DEFAULT_NOTES
-    notes = list(notes)
-    labels = [f"H{h.index+1}" for h in holes]
+    entries = _resolve_notes(notes)
+    tonehole_labels = [f"H{h.index+1}" for h in holes]
+    column_labels = [entry["label"] for entry in entries]
 
-    chart = [["label", *notes]]
-    template_lookup: Dict[str, Dict[str, object]] = {entry["note"]: entry for entry in FINGERING_TEMPLATE}
-    for label, hole in zip(labels, holes):
+    chart: List[List[object]] = [["label", *column_labels]]
+    for label, hole in zip(tonehole_labels, holes):
         row: List[object] = [label]
-        for note in notes:
-            state = template_lookup.get(note, {"holes": [1] * len(holes)})
-            holes_states: Sequence[float] = state["holes"]  # type: ignore[index]
+        for entry in entries:
+            holes_states: Sequence[object] = entry["holes"]
             idx = min(hole.index, len(holes_states) - 1)
-            value = holes_states[idx]
-            if isinstance(value, (int, float)):
-                row.append(value)
+            state = holes_states[idx]
+            if isinstance(state, (int, float)):
+                row.append(state)
             else:
-                row.append(1 if value else 0)
+                row.append(1 if state else 0)
         chart.append(row)
     return chart
 
 
 def fingering_sequence(notes: Iterable[str] | None = None) -> List[Dict[str, object]]:
-    """Return the fingering entries filtered by requested notes."""
+    """Return the fingering entries filtered by requested notes or labels."""
 
-    if notes is None:
-        return FINGERING_TEMPLATE
-    wanted = set(notes)
-    return [entry for entry in FINGERING_TEMPLATE if entry["note"] in wanted]
+    return _resolve_notes(notes)
 
 
-__all__ = ["FINGERING_TEMPLATE", "DEFAULT_NOTES", "build_fingering_chart", "fingering_sequence"]
+__all__ = [
+    "FINGERING_TEMPLATE",
+    "DEFAULT_NOTES",
+    "build_fingering_chart",
+    "fingering_sequence",
+]

--- a/server/openwind_service/geometry_builder.py
+++ b/server/openwind_service/geometry_builder.py
@@ -1,0 +1,368 @@
+"""Clarinet geometry builder driven by fingering charts and OpenWInD simulation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+
+from .fingerings_bb import FINGERING_TEMPLATE
+from .models import Geometry, ObjectiveWeights, RecommendRequest, SimulationOptions, ToneHole
+from .openwind_adapter import OpenWInDAdapter
+
+
+MM_TO_M = 1e-3
+M_TO_MM = 1e3
+
+
+_REGISTER_BOUNDARIES = {
+    "chalumeau": (-np.inf, 65),
+    "clarion": (65, 82),
+    "altissimo": (82, np.inf),
+}
+
+
+def _speed_of_sound(temp_c: float) -> float:
+    """Approximate speed of sound in m/s for a given temperature."""
+
+    return 331.4 + 0.6 * temp_c
+
+
+def _note_frequency(midi: int, a4_hz: float) -> float:
+    """Return the equal-tempered frequency for a MIDI number."""
+
+    return float(a4_hz * (2.0 ** ((midi - 69) / 12.0)))
+
+
+def _register_mode(midi: int) -> int:
+    """Return the odd mode index (1, 3, 5, ...) for the clarinet register."""
+
+    if midi >= _REGISTER_BOUNDARIES["altissimo"][0]:
+        return 5
+    if midi >= _REGISTER_BOUNDARIES["clarion"][0]:
+        return 3
+    return 1
+
+
+def _first_open_index(states: Sequence[object]) -> Tuple[int | None, bool]:
+    """Locate the first hole that is not fully closed.
+
+    Returns (index, is_half_hole) where index is ``None`` for the all-closed fingering.
+    """
+
+    for idx, raw in enumerate(states):
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            # Treat truthy values as open, falsy as closed.
+            if raw:
+                return idx, False
+            continue
+        if value >= 0.5:
+            return idx, value < 1.0
+    return None, False
+
+
+@dataclass
+class BuilderResult:
+    geometry: Geometry
+    notes: List[str]
+    convergence: List[float]
+    history: List[Dict[str, float]]
+    intonation: List[Dict[str, object]]
+
+
+class ClarinetGeometryBuilder:
+    """Generate a Bb clarinet geometry from a fingering chart and simulations."""
+
+    def __init__(
+        self,
+        adapter: OpenWInDAdapter | None = None,
+        simulation_options: SimulationOptions | None = None,
+    ) -> None:
+        self._adapter = adapter or OpenWInDAdapter()
+        self._simulation_options = simulation_options or SimulationOptions()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(self, payload: RecommendRequest) -> BuilderResult:
+        """Return an optimised clarinet geometry based on fingering data."""
+
+        entries = self._select_entries(payload)
+        notes = [entry["label"] for entry in entries]
+        base_geometry = self._geometry_from_fingerings(payload, entries)
+        options = self._options_for_payload(payload)
+        optimised, convergence, history = self._optimise_geometry(
+            payload, base_geometry, notes, options
+        )
+        fingering_checks, impedance_bundle = self._evaluate_fingerings(
+            optimised, options, notes
+        )
+
+        # Merge metadata with optimisation traces
+        metadata = {
+            **optimised.metadata,
+            "builder": "clarinet-fingering",
+            "convergence": convergence,
+            "history": history,
+            "fingering_intonation": fingering_checks,
+            "fingering_notes": notes,
+            **impedance_bundle,
+        }
+        optimised = optimised.model_copy(update={"metadata": metadata})
+        return BuilderResult(
+            geometry=optimised,
+            notes=notes,
+            convergence=convergence,
+            history=history,
+            intonation=fingering_checks,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _geometry_from_fingerings(
+        self, payload: RecommendRequest, entries: Sequence[Dict[str, object]]
+    ) -> Geometry:
+        """Construct an initial geometry consistent with the fingering chart."""
+
+        constraints = payload.constraints
+        bore_mm = float(
+            np.clip(14.6, constraints.min_bore_mm or 13.4, constraints.max_bore_mm or 15.1)
+        )
+
+        temp_c = self._simulation_options.temp_C
+        speed = _speed_of_sound(temp_c)
+
+        first_open_targets: Dict[int, List[float]] = defaultdict(list)
+        first_open_freqs: Dict[int, List[float]] = defaultdict(list)
+        all_closed_lengths: List[float] = []
+
+        for entry in entries:
+            midi = int(entry.get("midi", 0))
+            freq = _note_frequency(midi, payload.target_a4_hz)
+            mode = _register_mode(midi)
+            length_m = (mode * speed) / (4.0 * freq)
+
+            index, half = _first_open_index(entry.get("holes", []))
+            if index is None:
+                all_closed_lengths.append(length_m)
+                continue
+            first_open_targets[index].append(length_m)
+            if half:
+                # Penalise half-hole with slightly shorter target to encourage chimney levelling
+                first_open_targets[index][-1] *= 0.99
+            first_open_freqs[index].append(freq)
+
+        hole_count = len(entries[0]["holes"]) if entries else 0
+        if hole_count == 0:
+            raise ValueError("No fingering information provided for geometry construction.")
+
+        # Determine overall acoustic length using the all-closed fingering or the deepest tone hole.
+        if all_closed_lengths:
+            length_m = float(np.mean(all_closed_lengths))
+        else:
+            deepest = max(first_open_targets.keys(), default=hole_count - 1)
+            length_m = float(np.max(first_open_targets.get(deepest, [0.66])))
+
+        length_mm = length_m * M_TO_MM
+
+        spacing_min_mm = constraints.min_spacing_mm or 10.0
+        spacing_min_m = spacing_min_mm * MM_TO_M
+
+        positions: List[float] = []
+        prev = 0.015  # keep a short lead from the mouthpiece interface
+        for idx in range(hole_count):
+            targets = first_open_targets.get(idx)
+            if targets:
+                pos_m = float(np.mean(targets))
+            else:
+                # Interpolate between neighbours or extend the last spacing
+                if idx > 0 and positions:
+                    pos_m = positions[-1] + spacing_min_m
+                else:
+                    pos_m = prev + spacing_min_m
+
+            pos_m = max(prev + spacing_min_m, pos_m)
+            pos_m = min(pos_m, length_m - 0.04)  # ensure holes stay above the bell flare
+            positions.append(pos_m)
+            prev = pos_m
+
+        # Estimate diameters proportional to the target frequencies and bore
+        if first_open_freqs:
+            freq_values = np.concatenate(list(first_open_freqs.values()))
+            freq_min = float(np.min(freq_values))
+            freq_max = float(np.max(freq_values))
+        else:
+            freq_min = _note_frequency(48, payload.target_a4_hz)
+            freq_max = _note_frequency(84, payload.target_a4_hz)
+
+        diameters: List[float] = []
+        chimneys: List[float] = []
+        undercuts: List[float] = []
+        for idx in range(hole_count):
+            freq_list = first_open_freqs.get(idx)
+            if freq_list:
+                freq = float(np.mean(freq_list))
+            else:
+                # Interpolate frequency linearly across the bore
+                ratio = idx / max(hole_count - 1, 1)
+                freq = freq_min + ratio * (freq_max - freq_min)
+
+            norm = (freq - freq_min) / max(freq_max - freq_min, 1.0)
+            diameter = bore_mm * (0.45 + 0.4 * norm)
+            diameter = float(np.clip(diameter, 4.5, bore_mm * 1.25))
+            diameters.append(diameter)
+
+            chimney = max(12.0 - 0.35 * idx, 7.5)
+            chimneys.append(chimney)
+
+            undercut = float(np.clip(1.25 - 0.045 * idx, 0.35, 1.45))
+            undercuts.append(undercut)
+
+        holes = [
+            ToneHole(
+                index=idx,
+                axial_pos_mm=positions[idx] * M_TO_MM,
+                diameter_mm=diameters[idx],
+                chimney_mm=chimneys[idx],
+                undercut_mm=undercuts[idx],
+                closed=False,
+            )
+            for idx in range(hole_count)
+        ]
+
+        metadata = {
+            "fingerings_used": [entry["note"] for entry in entries],
+            "fingering_labels": [entry["label"] for entry in entries],
+            "speed_of_sound_mps": speed,
+            "initial_length_mm": length_mm,
+            "bell_profile": {"type": "bessel", "shape": 0.7},
+            "chimney_profile_mm": chimneys,
+            "undercut_profile_mm": undercuts,
+        }
+
+        geometry = Geometry(
+            bore_mm=bore_mm,
+            length_mm=length_mm,
+            tone_holes=holes,
+            metadata=metadata,
+        )
+        return geometry
+
+    def _optimise_geometry(
+        self,
+        payload: RecommendRequest,
+        geometry: Geometry,
+        notes: Sequence[str],
+        options: SimulationOptions,
+    ) -> Tuple[Geometry, List[float], List[Dict[str, float]]]:
+        """Refine geometry using OpenWInD impedance simulations."""
+
+        rng = np.random.default_rng(hash(payload.player_pref.profile.lower()) & 0xFFFF)
+
+        profile = payload.player_pref.profile.lower()
+        if profile == "bright":
+            objective = ObjectiveWeights(intonation=1.0, impedance_smoothness=0.15, register_alignment=0.35)
+        elif profile in {"dark", "warm"}:
+            objective = ObjectiveWeights(intonation=1.1, impedance_smoothness=0.4, register_alignment=0.65)
+        else:
+            objective = ObjectiveWeights()
+
+        max_iter = 15
+
+        def mutate(base: Geometry, iteration: int) -> Geometry:
+            clone = base.model_copy(deep=True)
+            scale = max(0.25, np.exp(-0.12 * iteration))
+            bore_delta = float(rng.normal(0.0, 0.05 * scale))
+            clone.bore_mm = float(np.clip(clone.bore_mm + bore_delta, 13.5, 15.5))
+            for idx, hole in enumerate(clone.tone_holes):
+                pos_delta = float(rng.normal(0.0, 0.6 * scale))
+                diam_delta = float(rng.normal(0.0, 0.4 * scale))
+                chim_delta = float(rng.normal(0.0, 0.3 * scale))
+                hole.axial_pos_mm = max(hole.axial_pos_mm + pos_delta, 18.0 + idx * 4.0)
+                hole.diameter_mm = float(np.clip(hole.diameter_mm + diam_delta, 4.0, clone.bore_mm * 1.3))
+                hole.chimney_mm = float(np.clip(hole.chimney_mm + chim_delta, 6.0, 14.0))
+
+            # Ensure monotonic positions
+            sorted_holes = sorted(clone.tone_holes, key=lambda h: h.axial_pos_mm)
+            for idx, hole in enumerate(sorted_holes):
+                min_pos = 15.0 + idx * (payload.constraints.min_spacing_mm or 10.0)
+                hole.axial_pos_mm = max(hole.axial_pos_mm, min_pos)
+            clone.tone_holes = sorted(sorted_holes, key=lambda h: h.index)
+            return clone
+
+        trace: List[Dict[str, float]] = []
+
+        def callback(iteration: int, score: float, geom: Geometry, metrics: Dict[str, float]) -> None:
+            trace.append({"iteration": iteration, "score": score, **metrics})
+
+        best_geom, convergence, _sensitivities, history = self._adapter.optimise_geometry(
+            geometry,
+            options,
+            objective,
+            max_iter,
+            mutate,
+            callback,
+            fingering_notes=notes,
+        )
+
+        # Combine optimiser history with callback trace for metadata
+        combined_history: List[Dict[str, float]] = []
+        trace_map = {int(item["iteration"]): item for item in trace}
+        for record in history:
+            iteration = int(record.get("iteration", -1))
+            merged = {**record, **trace_map.get(iteration, {})}
+            combined_history.append(merged)
+
+        return best_geom, convergence, combined_history
+
+    def _options_for_payload(self, payload: RecommendRequest) -> SimulationOptions:
+        options = self._simulation_options.model_copy(deep=True)
+        options.concert_pitch_hz = payload.target_a4_hz
+        return options
+
+    def _evaluate_fingerings(
+        self,
+        geometry: Geometry,
+        options: SimulationOptions,
+        notes: Sequence[str],
+    ) -> Tuple[List[Dict[str, object]], Dict[str, List[float]]]:
+        bundle = self._adapter.run_simulation(geometry, options, fingering_notes=notes)
+        checks: List[Dict[str, object]] = [
+            {
+                "note": item.note,
+                "midi": item.midi,
+                "target_hz": item.target_hz,
+                "resonance_hz": item.resonance_hz,
+                "cents": item.cents,
+            }
+            for item in bundle.intonation
+        ]
+        return checks, {
+            "frequencies": bundle.frequencies.tolist(),
+            "impedance_real": bundle.impedance.real.tolist(),
+            "impedance_imag": bundle.impedance.imag.tolist(),
+            "impedance_abs": np.abs(bundle.impedance).tolist(),
+        }
+
+    def _select_entries(self, payload: RecommendRequest) -> List[Dict[str, object]]:
+        """Filter fingering template entries according to requested register."""
+
+        register = (payload.include_register or "").lower()
+        if register in _REGISTER_BOUNDARIES:
+            low, high = _REGISTER_BOUNDARIES[register]
+            filtered = [
+                entry for entry in FINGERING_TEMPLATE if low <= entry.get("midi", 0) < high
+            ]
+            if filtered:
+                return filtered
+        # Use the full traditional French Bb clarinet set by default
+        return list(FINGERING_TEMPLATE)
+
+
+__all__ = ["ClarinetGeometryBuilder", "BuilderResult"]
+

--- a/server/openwind_service/models.py
+++ b/server/openwind_service/models.py
@@ -133,7 +133,6 @@ class OptRequest(BaseModel):
     seed: int = Field(default=1234)
     simulation: SimulationOptions = Field(default_factory=SimulationOptions)
     fingering_notes: Optional[List[str]] = None
-in
 
 
 class OptimizeResponse(BaseModel):

--- a/server/openwind_service/recommend.py
+++ b/server/openwind_service/recommend.py
@@ -1,87 +1,28 @@
-"""Generate starting geometries for a Bb clarinet."""
+"""Generate Bb clarinet geometries driven by fingering charts and simulations."""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
 
-import numpy as np
+from .geometry_builder import ClarinetGeometryBuilder
+from .models import RecommendRequest, RecommendResponse
 
-from .models import Geometry, RecommendRequest, RecommendResponse, ToneHole
 
-_DEFAULT_BORE_MM = 14.6
-_DEFAULT_LENGTH_MM = 660.0
-_DEFAULT_CHIMNEY_MM = 12.0
-
-# canonical offsets in millimetres from the top of the upper joint
-_BASE_HOLE_POSITIONS = np.array([
-    35, 63, 91, 119, 147, 175, 203, 231, 259, 287, 315, 343, 371, 399, 427, 455, 490
-])
-_BASE_HOLE_DIAMETERS = np.array([
-    11.0, 8.5, 7.2, 6.5, 6.0, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 8.8, 10.5, 12.5, 14.2, 15.0, 16.0
-])
+_BUILDER = ClarinetGeometryBuilder()
 
 
 def recommend_geometry(payload: RecommendRequest) -> RecommendResponse:
-    """Create a :class:`Geometry` based on heuristics and request constraints."""
+    """Create and optimise a :class:`~openwind_service.models.Geometry` instance."""
 
-    constraints = payload.constraints
-    bore_mm = np.clip(
-        _DEFAULT_BORE_MM,
-        constraints.min_bore_mm or 13.5,
-        constraints.max_bore_mm or 15.2,
+    result = _BUILDER.build(payload)
+    geometry = result.geometry.model_copy(update={
+        "mouthpiece_params": {"reed_strength": payload.player_pref.profile}
+    })
+    return RecommendResponse(
+        geometry=geometry,
+        notes=result.notes,
+        created_at=datetime.utcnow(),
     )
-
-    length_mm = _DEFAULT_LENGTH_MM
-    target_a4 = payload.target_a4_hz
-    if target_a4 >= 442:
-        length_mm *= 0.997
-    elif target_a4 <= 438:
-        length_mm *= 1.004
-
-    hole_count = len(_BASE_HOLE_POSITIONS)
-    if constraints.min_hole_count is not None:
-        hole_count = max(hole_count, constraints.min_hole_count)
-    if constraints.max_hole_count is not None:
-        hole_count = min(hole_count, constraints.max_hole_count)
-
-    scale = (length_mm - 120.0) / (_BASE_HOLE_POSITIONS[-1] - _BASE_HOLE_POSITIONS[0])
-    spacing_min = constraints.min_spacing_mm or 10.0
-    holes: List[ToneHole] = []
-    previous = 0.0
-
-    for idx in range(hole_count):
-        base_pos = _BASE_HOLE_POSITIONS[min(idx, len(_BASE_HOLE_POSITIONS) - 1)]
-        pos_mm = max(previous + spacing_min, base_pos * scale)
-        diameter = float(_BASE_HOLE_DIAMETERS[min(idx, len(_BASE_HOLE_DIAMETERS) - 1)])
-        diameter = np.clip(diameter, 5.0, bore_mm * 1.2)
-        chimney_mm = max(_DEFAULT_CHIMNEY_MM - 0.2 * idx, 8.0)
-        holes.append(
-            ToneHole(
-                index=idx,
-                axial_pos_mm=pos_mm,
-                diameter_mm=diameter,
-                chimney_mm=chimney_mm,
-                closed=False,
-            )
-        )
-        previous = pos_mm
-
-    geometry = Geometry(
-        bore_mm=float(bore_mm),
-        length_mm=float(length_mm),
-        tone_holes=holes,
-        mouthpiece_params={"reed_strength": payload.player_pref.profile},
-        metadata={
-            "target_a4_hz": payload.target_a4_hz,
-            "scale": payload.scale,
-            "player_pref": payload.player_pref.profile,
-            "min_spacing_mm": spacing_min,
-
-        },
-    )
-    notes = [fnote for fnote in (payload.include_register, "standard", "altissimo") if fnote]
-    return RecommendResponse(geometry=geometry, notes=notes, created_at=datetime.utcnow())
 
 
 __all__ = ["recommend_geometry"]


### PR DESCRIPTION
## Summary
- expand the French Bb clarinet fingering chart with automatically generated alternate variants and richer filtering helpers
- update the fingering-driven clarinet geometry builder to include undercut heuristics, optimisation metadata, and post-run intonation checks across all fingerings
- teach the OpenWInD adapter to use the variant-aware fingering labels when building charts and reporting intonation results

## Testing
- python -m compileall server/openwind_service


------
https://chatgpt.com/codex/tasks/task_e_68de3f1123588328ae9472faf368fb06