### PR TITLE
feat(ui): expose recommendation controls and undercut editing

### DIFF
--- a/ui/src/lib/constants.js
+++ b/ui/src/lib/constants.js
@@ -9,3 +9,9 @@ export const DEFAULT_NOTES = [
 
 export const TRANSPOSITIONS = ['Bb', 'A', 'C', 'F', 'Eb'];
 
+export const RECOMMENDATION_SCALES = ['equal', 'just'];
+export const PLAYER_PROFILES = ['balanced', 'bright', 'warm', 'dark'];
+export const PLAYER_ARTICULATIONS = ['standard', 'legato', 'staccato'];
+export const PLAYER_BRIGHTNESS = ['neutral', 'warm', 'bright'];
+export const REGISTER_OPTIONS = ['standard', 'chalumeau', 'clarion', 'altissimo'];
+

--- a/ui/src/lib/validators.js
+++ b/ui/src/lib/validators.js
@@ -20,7 +20,8 @@ export function sanitizeGeometry(geometry) {
       ...hole,
       axial_pos_mm: Math.max(hole.axial_pos_mm, 1),
       diameter_mm: Math.max(hole.diameter_mm, 2),
-      chimney_mm: Math.max(hole.chimney_mm, 2)
+      chimney_mm: Math.max(hole.chimney_mm, 2),
+      undercut_mm: hole.undercut_mm == null ? 0.8 : Math.max(hole.undercut_mm, 0)
     }))
   };
 }

--- a/ui/src/lib/workspace.jsx
+++ b/ui/src/lib/workspace.jsx
@@ -30,6 +30,15 @@ const defaultSimulationOptions = {
 
 };
 
+const defaultRecommendationOptions = {
+  targetA4Hz: 440,
+  scale: 'equal',
+  includeRegister: 'standard',
+  playerProfile: 'balanced',
+  playerArticulation: 'standard',
+  playerBrightness: 'neutral'
+};
+
 const WorkspaceContext = createContext(null);
 
 export function WorkspaceProvider({ children }) {
@@ -51,6 +60,11 @@ export function WorkspaceProvider({ children }) {
   const [simulationResult, setSimulationResult] = useState(() => stored.simulation ?? null);
   const [optimizationResult, setOptimizationResult] = useState(() => stored.optimization ?? null);
   const [lastRecommendation, setLastRecommendation] = useState(() => stored.lastRecommendation ?? null);
+  const [recommendationOptions, setRecommendationOptionsState] = useState(() => ({
+    ...defaultRecommendationOptions,
+    ...(stored.recommendation ?? {}),
+    targetA4Hz: stored.recommendation?.targetA4Hz ?? stored.a4 ?? defaultRecommendationOptions.targetA4Hz
+  }));
 
   useEffect(() => {
     saveSettings({
@@ -61,7 +75,9 @@ export function WorkspaceProvider({ children }) {
       autosimulate,
       simulation: simulationResult,
       optimization: optimizationResult,
-      lastRecommendation
+      lastRecommendation,
+      recommendation: recommendationOptions,
+      a4: recommendationOptions.targetA4Hz
     });
   }, [
     geometry,
@@ -71,7 +87,8 @@ export function WorkspaceProvider({ children }) {
     autosimulate,
     simulationResult,
     optimizationResult,
-    lastRecommendation
+    lastRecommendation,
+    recommendationOptions
   ]);
 
   const setGeometry = useCallback((update) => {
@@ -105,6 +122,13 @@ export function WorkspaceProvider({ children }) {
     setAutosimulateState(Boolean(value));
   }, []);
 
+  const setRecommendationOptions = useCallback((update) => {
+    setRecommendationOptionsState((previous) => ({
+      ...previous,
+      ...(typeof update === 'function' ? update(previous) : update)
+    }));
+  }, []);
+
   const resetWorkspace = useCallback(() => {
     setGeometryState(sanitizeGeometry(defaultGeometry));
     setConstraintsState(defaultConstraints);
@@ -114,6 +138,7 @@ export function WorkspaceProvider({ children }) {
     setSimulationResult(null);
     setOptimizationResult(null);
     setLastRecommendation(null);
+    setRecommendationOptionsState(defaultRecommendationOptions);
   }, []);
 
   const value = useMemo(
@@ -134,6 +159,8 @@ export function WorkspaceProvider({ children }) {
       setOptimizationResult,
       lastRecommendation,
       setLastRecommendation,
+      recommendationOptions,
+      setRecommendationOptions,
       resetWorkspace
     }),
     [
@@ -147,6 +174,7 @@ export function WorkspaceProvider({ children }) {
       simulationResult,
       optimizationResult,
       lastRecommendation,
+      recommendationOptions,
       resetWorkspace
     ]
   );

--- a/ui/src/pages/Geometry.jsx
+++ b/ui/src/pages/Geometry.jsx
@@ -299,7 +299,36 @@ export function GeometryPage() {
 
   return (
     <div className="page-grid geometry-grid">
+      <Card className="guidance-card" title="How to shape your instrument">
+        <p>
+          Start with the bore dimensions, then review each tone hole row in the table below. You can
+          drag the order, duplicate entries or remove them entirely. If a value falls outside the
+          recommended range, a red hint will appear so you know what to adjust.
+        </p>
+        <ol>
+          <li>
+            Set your desired concert pitch and player preferences in “Recommendation options” to
+            receive tailored layouts.
+          </li>
+          <li>
+            Confirm the bore, instrument length and barrel dimensions – these set the physical scale
+            for every calculation.
+          </li>
+          <li>
+            Edit tone holes directly in the table. Buttons on the right let you reorder, clone or
+            delete rows in one click.
+          </li>
+          <li>
+            Adjust the constraints at the bottom if you want the automatic tools to explore a wider
+            (or tighter) range of designs.
+          </li>
+        </ol>
+      </Card>
       <Card title="Recommendation options">
+        <p>
+          Tell OpenWInD what kind of player and repertoire you are targeting. These preferences feed
+          into the server-side recommender that can populate the tone-hole layout for you.
+        </p>
         <div className="grid-two">
           <NumberField
             label="Target A4"
@@ -308,10 +337,15 @@ export function GeometryPage() {
             step={0.1}
             min={430}
             max={450}
+            description="Sets the reference pitch for all automatic suggestions."
             onChange={(value) => setRecommendationOptions((prev) => ({ ...prev, targetA4Hz: value }))}
           />
           <label className="ow-select">
             <span>Pitch scale</span>
+            <p className="select-help">
+              Choose the tuning system that best matches your ensemble. Equal temperament is the
+              modern default.
+            </p>
             <select
               value={recommendationOptions.scale}
               onChange={(event) => setRecommendationOptions((prev) => ({ ...prev, scale: event.target.value }))}
@@ -325,6 +359,7 @@ export function GeometryPage() {
           </label>
           <label className="ow-select">
             <span>Register focus</span>
+            <p className="select-help">Tell the recommender which playing register to favour.</p>
             <select
               value={recommendationOptions.includeRegister}
               onChange={(event) =>
@@ -340,6 +375,7 @@ export function GeometryPage() {
           </label>
           <label className="ow-select">
             <span>Player profile</span>
+            <p className="select-help">Match the response to the experience level of the player.</p>
             <select
               value={recommendationOptions.playerProfile}
               onChange={(event) =>
@@ -355,6 +391,7 @@ export function GeometryPage() {
           </label>
           <label className="ow-select">
             <span>Articulation</span>
+            <p className="select-help">Fine-tune how resistant or flexible the tone holes should feel.</p>
             <select
               value={recommendationOptions.playerArticulation}
               onChange={(event) =>
@@ -370,6 +407,7 @@ export function GeometryPage() {
           </label>
           <label className="ow-select">
             <span>Brightness</span>
+            <p className="select-help">Pick a tonal colour ranging from dark and mellow to bright.</p>
             <select
               value={recommendationOptions.playerBrightness}
               onChange={(event) =>
@@ -396,10 +434,32 @@ export function GeometryPage() {
           </div>
         }
       >
+        <p>
+          These core dimensions define the clarinet body. They accept sensible defaults, so feel free
+          to experiment – you can always reload the preset above.
+        </p>
         <div className="grid-two">
-          <NumberField label="Bore" value={geometry.bore_mm} unit="mm" onChange={(value) => setGeometry((prev) => ({ ...prev, bore_mm: value }))} />
-          <NumberField label="Length" value={geometry.length_mm} unit="mm" onChange={(value) => setGeometry((prev) => ({ ...prev, length_mm: value }))} />
-          <NumberField label="Barrel" value={geometry.barrel_length_mm} unit="mm" onChange={(value) => setGeometry((prev) => ({ ...prev, barrel_length_mm: value }))} />
+          <NumberField
+            label="Bore"
+            value={geometry.bore_mm}
+            unit="mm"
+            description="Internal diameter of the main bore. Larger values generally darken the tone."
+            onChange={(value) => setGeometry((prev) => ({ ...prev, bore_mm: value }))}
+          />
+          <NumberField
+            label="Length"
+            value={geometry.length_mm}
+            unit="mm"
+            description="Overall tube length from mouthpiece to bell end."
+            onChange={(value) => setGeometry((prev) => ({ ...prev, length_mm: value }))}
+          />
+          <NumberField
+            label="Barrel"
+            value={geometry.barrel_length_mm}
+            unit="mm"
+            description="Length of the detachable barrel section at the top of the clarinet."
+            onChange={(value) => setGeometry((prev) => ({ ...prev, barrel_length_mm: value }))}
+          />
         </div>
         <Switch
           id="autosimulate-toggle"
@@ -417,6 +477,10 @@ export function GeometryPage() {
           </Button>
         }
       >
+        <p>
+          Enter measurements for each tone hole. Hover over the “State” chip to toggle between open
+          and closed fingerings. Use the arrow buttons to reorder the layout without retyping values.
+        </p>
         <Table columns={columns} data={geometry.tone_holes} />
         {issues.length > 0 && (
           <div className="validation-block" role="alert">
@@ -430,6 +494,10 @@ export function GeometryPage() {
         )}
       </Card>
       <Card title="Constraints">
+        <p>
+          Constraints keep automatic tools within practical limits. If you want broader
+          experimentation, widen these values; for production-ready plans, tighten them.
+        </p>
         <div className="grid-two">
           <NumberField
             label="Minimum spacing"
@@ -437,6 +505,7 @@ export function GeometryPage() {
             unit="mm"
             min={2}
             step={0.5}
+            description="Enforces a safe minimum distance between tone holes."
             onChange={(value) => setConstraints({ minSpacingMm: value })}
           />
           <NumberField
@@ -445,6 +514,7 @@ export function GeometryPage() {
             unit="mm"
             min={2}
             step={0.1}
+            description="Prevents the recommender from suggesting unplayably small holes."
             onChange={(value) => setConstraints({ minDiameterMm: value })}
           />
           <NumberField
@@ -453,6 +523,7 @@ export function GeometryPage() {
             unit="mm"
             min={constraints.minDiameterMm}
             step={0.1}
+            description="Upper limit for hole size, keeping ergonomics comfortable."
             onChange={(value) => setConstraints({ maxDiameterMm: value })}
           />
           <NumberField
@@ -460,6 +531,7 @@ export function GeometryPage() {
             value={constraints.maxHoleCount}
             min={1}
             step={1}
+            description="Caps how many tone holes the automatic tools may create."
             onChange={(value) => setConstraints({ maxHoleCount: Math.round(value) })}
           />
         </div>

--- a/ui/src/pages/Home.jsx
+++ b/ui/src/pages/Home.jsx
@@ -49,14 +49,19 @@ export function Home() {
       .slice(1)
       .map((hole, index) => hole.axial_pos_mm - holes[index].axial_pos_mm)
       .filter((value) => Number.isFinite(value));
+    const undercuts = holes.map((hole) => hole.undercut_mm ?? 0).filter((value) => Number.isFinite(value));
     const minSpacing = spacing.length ? Math.min(...spacing) : null;
     const maxSpacing = spacing.length ? Math.max(...spacing) : null;
+    const minUndercut = undercuts.length ? Math.min(...undercuts) : null;
+    const maxUndercut = undercuts.length ? Math.max(...undercuts) : null;
     return {
       count: holes.length,
       closed,
       open: holes.length - closed,
       minSpacing,
-      maxSpacing
+      maxSpacing,
+      minUndercut,
+      maxUndercut
     };
   }, [geometry]);
 
@@ -113,6 +118,14 @@ export function Home() {
               {summary.minSpacing === null
                 ? '—'
                 : `${summary.minSpacing.toFixed(1)}–${summary.maxSpacing.toFixed(1)} mm`}
+            </dd>
+          </div>
+          <div>
+            <dt>Undercut range</dt>
+            <dd>
+              {summary.minUndercut === null
+                ? '—'
+                : `${summary.minUndercut.toFixed(2)}–${summary.maxUndercut.toFixed(2)} mm`}
             </dd>
           </div>
           <div>

--- a/ui/src/pages/Home.jsx
+++ b/ui/src/pages/Home.jsx
@@ -67,6 +67,31 @@ export function Home() {
 
   return (
     <div className="page-grid">
+      <Card className="guidance-card" title="Welcome to OpenWInD">
+        <p>
+          This workspace walks you through the complete clarinet design cycle. If you are new to
+          acoustics or CAD, follow the numbered steps below – the defaults are safe, and every
+          screen offers plain-language summaries before you commit to a change.
+        </p>
+        <ol>
+          <li>
+            <strong>Geometry:</strong> describe the physical instrument by editing tone holes, bore
+            length and constraints. Helpful hints explain every field.
+          </li>
+          <li>
+            <strong>Simulation:</strong> run OpenWInD’s physics model to hear how your design will
+            respond. Charts and tables highlight what the numbers mean.
+          </li>
+          <li>
+            <strong>Optimization &amp; Results:</strong> let the server suggest improvements, compare
+            them to your baseline and download shareable files when you are satisfied.
+          </li>
+        </ol>
+        <p>
+          You can jump back to this overview at any time; nothing is saved until you explicitly
+          export or copy a design.
+        </p>
+      </Card>
       <Card
         title="Quick start"
         action={
@@ -76,13 +101,26 @@ export function Home() {
         }
       >
         <p>
-          Use the preset to populate the geometry builder, then adjust the tone holes and simulate the impedance in real-time.
+          Not sure where to start? Load a factory Bb clarinet to explore how values change. You can
+          always return to the preset or undo changes later.
         </p>
         <ul>
-          <li>Geometry Builder: adjust bore, barrel and tone-hole layout with validation.</li>
-          <li>Simulation: visualize impedance and intonation against the concert pitch.</li>
-          <li>Optimization: stream progress with SSE and compare convergence.</li>
-          <li>Results: export JSON, CSV, DXF and STEP (when CadQuery is available).</li>
+          <li>
+            <strong>1. Geometry builder:</strong> adjust bore, barrel and tone-hole layout with live
+            validation messages.
+          </li>
+          <li>
+            <strong>2. Simulation:</strong> visualize how the instrument will sound compared with
+            standard concert pitch.
+          </li>
+          <li>
+            <strong>3. Optimization:</strong> stream server-side suggestions in real time and decide
+            whether to apply them.
+          </li>
+          <li>
+            <strong>4. Results:</strong> export JSON, CSV, DXF or STEP files to share with makers or
+            CAD tools.
+          </li>
         </ul>
         <div className="quick-links">
           <Button as={Link} to="/geometry" variant="secondary">
@@ -101,6 +139,10 @@ export function Home() {
           </Button>
         }
       >
+        <p>
+          These figures summarise your current design. Use them as a dashboard – if anything looks
+          unusual, revisit the geometry before running a new simulation or export.
+        </p>
         <dl className="workspace-summary">
           <div>
             <dt>Tone holes</dt>
@@ -136,14 +178,22 @@ export function Home() {
         <div className="workspace-status-grid">
           <section>
             <h3>Simulation</h3>
-            <p>{simulationResult ? `Last run: ${simulationResult.freq_hz.length} points` : 'No runs yet.'}</p>
+            <p>
+              {simulationResult
+                ? `Last run: ${simulationResult.freq_hz.length} frequency points evaluated.`
+                : 'No runs yet – head to Simulation to test how your design behaves.'}
+            </p>
             <Button as={Link} to="/simulation" variant="secondary" size="sm">
               Review simulation
             </Button>
           </section>
           <section>
             <h3>Optimization</h3>
-            <p>{optimizationResult ? `Job ${optimizationResult.job_id} (${optimizationResult.status})` : 'No jobs yet.'}</p>
+            <p>
+              {optimizationResult
+                ? `Job ${optimizationResult.job_id} (${optimizationResult.status}).`
+                : 'No jobs yet – visit Optimization to request server suggestions.'}
+            </p>
             <Button as={Link} to="/optimization" variant="secondary" size="sm">
               Manage optimization
             </Button>
@@ -151,6 +201,10 @@ export function Home() {
         </div>
       </Card>
       <Card title="API status">
+        <p>
+          If you ever see errors, check this status block – it mirrors the server response used by
+          the UI. A value of <code>null</code> simply means the application is still loading.
+        </p>
         <pre className="status-block">{JSON.stringify(health, null, 2)}</pre>
       </Card>
     </div>

--- a/ui/src/pages/Optimization.jsx
+++ b/ui/src/pages/Optimization.jsx
@@ -117,11 +117,48 @@ export function OptimizationPage() {
 
   return (
     <div className="page-grid optimization-grid">
+      <Card className="guidance-card" title="Let OpenWInD suggest improvements">
+        <p>
+          Optimization runs a series of server-side simulations to nudge your design toward chosen
+          goals. If you are unsure about any field, hover the labels – each one now spells out what it
+          controls in everyday language.
+        </p>
+        <ol>
+          <li>
+            Decide what you want to improve first: intonation accuracy, impedance smoothness or
+            register alignment.
+          </li>
+          <li>Confirm how far the algorithm may move each parameter in “Bounds &amp; settings”.</li>
+          <li>
+            Start the job and watch the live log. You can stop at any time, then load the best result
+            in the Results page.
+          </li>
+        </ol>
+      </Card>
       <Card title="Objective weights">
+        <p>
+          The optimizer blends these numbers into a single score. Higher values make that aspect more
+          important when searching for solutions.
+        </p>
         <div className="grid-two">
-          <NumberField label="Intonation" value={objective.intonation} onChange={(value) => setObjective((prev) => ({ ...prev, intonation: value }))} />
-          <NumberField label="Impedance smoothness" value={objective.impedance_smoothness} onChange={(value) => setObjective((prev) => ({ ...prev, impedance_smoothness: value }))} />
-          <NumberField label="Register alignment" value={objective.register_alignment} onChange={(value) => setObjective((prev) => ({ ...prev, register_alignment: value }))} />
+          <NumberField
+            label="Intonation"
+            value={objective.intonation}
+            description="Prioritise tuning accuracy across your selected notes."
+            onChange={(value) => setObjective((prev) => ({ ...prev, intonation: value }))}
+          />
+          <NumberField
+            label="Impedance smoothness"
+            value={objective.impedance_smoothness}
+            description="Encourage evenly spaced impedance peaks for a consistent response."
+            onChange={(value) => setObjective((prev) => ({ ...prev, impedance_smoothness: value }))}
+          />
+          <NumberField
+            label="Register alignment"
+            value={objective.register_alignment}
+            description="Helps the throat, clarion and altissimo registers line up in pitch."
+            onChange={(value) => setObjective((prev) => ({ ...prev, register_alignment: value }))}
+          />
         </div>
       </Card>
       <Card
@@ -135,12 +172,44 @@ export function OptimizationPage() {
           </div>
         }
       >
+        <p>
+          Bounds limit how radically the optimizer may alter your design. Start with the defaults; if
+          changes feel too subtle, expand them gradually.
+        </p>
         <div className="grid-two">
-          <NumberField label="Bore delta" value={bounds.bore_delta_mm} unit="mm" onChange={(value) => setBounds((prev) => ({ ...prev, bore_delta_mm: value }))} />
-          <NumberField label="Hole diameter delta" value={bounds.hole_diameter_delta_mm} unit="mm" onChange={(value) => setBounds((prev) => ({ ...prev, hole_diameter_delta_mm: value }))} />
-          <NumberField label="Hole position delta" value={bounds.hole_position_delta_mm} unit="mm" onChange={(value) => setBounds((prev) => ({ ...prev, hole_position_delta_mm: value }))} />
-          <NumberField label="Max iterations" value={maxIter} onChange={(value) => setMaxIter(Math.max(5, Math.round(value)))} />
-          <NumberField label="Seed" value={seed} onChange={(value) => setSeed(Math.round(value))} />
+          <NumberField
+            label="Bore delta"
+            value={bounds.bore_delta_mm}
+            unit="mm"
+            description="Maximum bore adjustment per step. Larger values explore bolder shapes."
+            onChange={(value) => setBounds((prev) => ({ ...prev, bore_delta_mm: value }))}
+          />
+          <NumberField
+            label="Hole diameter delta"
+            value={bounds.hole_diameter_delta_mm}
+            unit="mm"
+            description="How much each tone hole can widen or narrow during optimisation."
+            onChange={(value) => setBounds((prev) => ({ ...prev, hole_diameter_delta_mm: value }))}
+          />
+          <NumberField
+            label="Hole position delta"
+            value={bounds.hole_position_delta_mm}
+            unit="mm"
+            description="Maximum axial movement allowed for tone holes between iterations."
+            onChange={(value) => setBounds((prev) => ({ ...prev, hole_position_delta_mm: value }))}
+          />
+          <NumberField
+            label="Max iterations"
+            value={maxIter}
+            description="More iterations give the optimiser extra chances to refine the design."
+            onChange={(value) => setMaxIter(Math.max(5, Math.round(value)))}
+          />
+          <NumberField
+            label="Seed"
+            value={seed}
+            description="Fixed seeds make runs repeatable; change it to explore alternative paths."
+            onChange={(value) => setSeed(Math.round(value))}
+          />
         </div>
         <div className="progress-row">
           <label htmlFor="optimization-progress">Progress</label>
@@ -156,6 +225,10 @@ export function OptimizationPage() {
         />
       </Card>
       <Card title="Progress log">
+        <p>
+          Messages arrive in real time as the server works. “Score” highlights the current best
+          design; you can stop whenever the improvements level off.
+        </p>
         <ul className="log" aria-live="polite">
           {events.map((event, index) => (
             <li key={index}>
@@ -169,6 +242,10 @@ export function OptimizationPage() {
         </ul>
       </Card>
       <Card title="Convergence">
+        <p>
+          This chart shows how the optimisation score changes over time. A flat line means the
+          algorithm has settled on the best answer it can find.
+        </p>
         <ChartConvergence data={convergence} />
       </Card>
       {optimizationResult && (
@@ -180,7 +257,10 @@ export function OptimizationPage() {
             </Button>
           }
         >
-          <p>Job {optimizationResult.job_id} finished {optimizationResult.status}.</p>
+          <p>
+            Job {optimizationResult.job_id} finished {optimizationResult.status}. Review the Results
+            page to inspect the geometry in detail or download exports.
+          </p>
         </Card>
       )}
     </div>

--- a/ui/src/pages/Results.jsx
+++ b/ui/src/pages/Results.jsx
@@ -124,7 +124,23 @@ export function ResultsPage() {
 
   return (
     <div className="page-grid results-grid">
+      <Card className="guidance-card" title="Check, compare and share your work">
+        <p>
+          Results gathers everything you have produced so far. Use it to pull in optimisation jobs,
+          compare them with your current geometry and download files that instrument makers or CAD
+          packages can open without extra processing.
+        </p>
+        <ol>
+          <li>Fetch an optimisation job if you ran one earlier – the ID comes from the live log.</li>
+          <li>Review the tables and charts to understand how the geometry changed.</li>
+          <li>Export clean files in the format your collaborators prefer.</li>
+        </ol>
+      </Card>
       <Card title="Exports" action={<Button onClick={loadResult}>Load job</Button>}>
+        <p>
+          Paste an optimisation job identifier to refresh the data, then choose an export format. We
+          keep the latest download link handy so you can share it immediately.
+        </p>
         <div className="export-actions">
           <input value={jobId} onChange={(event) => setJobId(event.target.value)} placeholder="Optimization job id" />
           <div className="export-buttons">
@@ -153,21 +169,41 @@ export function ResultsPage() {
           )
         }
       >
+        <p>
+          This table reflects the geometry currently loaded in your workspace – edit the geometry page
+          and the numbers here will update instantly.
+        </p>
         <Table columns={holeColumns} data={geometry.tone_holes ?? []} />
       </Card>
       {optimizationResult && (
         <>
           <Card title="Before vs after">
+            <p>
+              Compare each tone hole from your baseline against the optimised layout. Deltas show how
+              far the algorithm moved every dimension.
+            </p>
             <Table columns={comparisonColumns} data={comparisonData} />
           </Card>
           <Card title="Convergence">
+            <p>
+              A downward curve means the optimisation kept finding better solutions. Plateaus indicate
+              the run has stabilised.
+            </p>
             <ChartConvergence data={optimizationResult.convergence} />
           </Card>
           <Card title="Sensitivity">
+            <p>
+              Sensitivity highlights which design parameters influenced the score most. Focus your
+              manual tweaks on the highest bars for bigger impact.
+            </p>
             <ChartSensitivity data={optimizationResult.sensitivity} />
           </Card>
           {metricsSummary && (
             <Card title="Final metrics">
+              <p>
+                These figures summarise the last optimisation step. Lower RMSE values indicate more
+                accurate tuning, while higher composite scores mean a better overall fit.
+              </p>
               <dl className="metrics-grid">
                 <div>
                   <dt>Composite score</dt>
@@ -196,6 +232,10 @@ export function ResultsPage() {
           <p>
             {simulationResult.intonation.length} notes analysed with frequency range {simulationResult.freq_hz[0].toFixed(1)}–
             {simulationResult.freq_hz.at(-1).toFixed(1)} Hz.
+          </p>
+          <p>
+            Use this summary as a reminder of the environment assumed by the optimisation. Re-run the
+            simulation after applying a new geometry to keep everything in sync.
           </p>
         </Card>
       )}

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -32,20 +32,60 @@ export function SettingsPage() {
 
   return (
     <div className="page-grid">
+      <Card className="guidance-card" title="Tailor the workspace to your environment">
+        <p>
+          Settings synchronise the defaults used across geometry recommendations and simulations. If
+          you rehearse in unusual conditions (cold halls, alternative pitch standards), dial those in
+          here once and the rest of the app will follow.
+        </p>
+        <ul>
+          <li>
+            <strong>Concert A4:</strong> updates both the recommender and simulation reference pitch.
+          </li>
+          <li>
+            <strong>Temperature and frequency range:</strong> ensure the model matches your playing
+            environment.
+          </li>
+          <li>Toggle dark mode if you prefer a brighter interface for printouts or presentations.</li>
+        </ul>
+      </Card>
       <Card title="Environment">
+        <p>
+          These values are stored locally in your browser. Adjust them whenever your rehearsal space
+          changes – OpenWInD will remember them next time you sign in.
+        </p>
         <div className="grid-two">
           <NumberField
             label="Concert A4"
             value={settings.a4}
             unit="Hz"
+            description="Standard orchestral tuning is 440 Hz; some ensembles use 442 Hz or higher."
             onChange={(value) => {
               setSettings((prev) => ({ ...prev, a4: value }));
               setRecommendationOptions((prev) => ({ ...prev, targetA4Hz: value }));
             }}
           />
-          <NumberField label="Temperature" value={settings.temperature} unit="°C" onChange={(value) => setSettings((prev) => ({ ...prev, temperature: value }))} />
-          <NumberField label="Frequency min" value={settings.freq_min} unit="Hz" onChange={(value) => setSettings((prev) => ({ ...prev, freq_min: value }))} />
-          <NumberField label="Frequency max" value={settings.freq_max} unit="Hz" onChange={(value) => setSettings((prev) => ({ ...prev, freq_max: value }))} />
+          <NumberField
+            label="Temperature"
+            value={settings.temperature}
+            unit="°C"
+            description="Used as the starting point for new simulations."
+            onChange={(value) => setSettings((prev) => ({ ...prev, temperature: value }))}
+          />
+          <NumberField
+            label="Frequency min"
+            value={settings.freq_min}
+            unit="Hz"
+            description="Default low end for impedance plots and exports."
+            onChange={(value) => setSettings((prev) => ({ ...prev, freq_min: value }))}
+          />
+          <NumberField
+            label="Frequency max"
+            value={settings.freq_max}
+            unit="Hz"
+            description="Default high end for impedance plots and exports."
+            onChange={(value) => setSettings((prev) => ({ ...prev, freq_max: value }))}
+          />
         </div>
         <Switch
           id="dark-mode"

--- a/ui/src/pages/Settings.jsx
+++ b/ui/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { NumberField } from '../components/NumberField.jsx';
 import { Switch } from '../components/Switch.jsx';
 import { loadSettings, saveSettings } from '../lib/storage.js';
 import { useToast } from '../components/Toast.jsx';
+import { useWorkspace } from '../lib/workspace.jsx';
 
 export function SettingsPage() {
   const stored = loadSettings();
@@ -15,16 +16,33 @@ export function SettingsPage() {
     darkMode: true
   });
   const { notify } = useToast();
+  const { recommendationOptions, setRecommendationOptions } = useWorkspace();
 
   useEffect(() => {
     saveSettings(settings);
   }, [settings]);
 
+  useEffect(() => {
+    setSettings((prev) =>
+      prev.a4 === recommendationOptions.targetA4Hz
+        ? prev
+        : { ...prev, a4: recommendationOptions.targetA4Hz }
+    );
+  }, [recommendationOptions.targetA4Hz]);
+
   return (
     <div className="page-grid">
       <Card title="Environment">
         <div className="grid-two">
-          <NumberField label="Concert A4" value={settings.a4} unit="Hz" onChange={(value) => setSettings((prev) => ({ ...prev, a4: value }))} />
+          <NumberField
+            label="Concert A4"
+            value={settings.a4}
+            unit="Hz"
+            onChange={(value) => {
+              setSettings((prev) => ({ ...prev, a4: value }));
+              setRecommendationOptions((prev) => ({ ...prev, targetA4Hz: value }));
+            }}
+          />
           <NumberField label="Temperature" value={settings.temperature} unit="°C" onChange={(value) => setSettings((prev) => ({ ...prev, temperature: value }))} />
           <NumberField label="Frequency min" value={settings.freq_min} unit="Hz" onChange={(value) => setSettings((prev) => ({ ...prev, freq_min: value }))} />
           <NumberField label="Frequency max" value={settings.freq_max} unit="Hz" onChange={(value) => setSettings((prev) => ({ ...prev, freq_max: value }))} />

--- a/ui/src/pages/Simulation.jsx
+++ b/ui/src/pages/Simulation.jsx
@@ -143,6 +143,21 @@ export function SimulationPage() {
 
   return (
     <div className="page-grid simulation-grid">
+      <Card className="guidance-card" title="Understand how your design will sound">
+        <p>
+          This page sends your current geometry to the OpenWInD physics engine. You can run it once
+          or let it update automatically as you tweak values. The summaries below translate the
+          technical output into plain language so you can focus on musical decisions.
+        </p>
+        <ol>
+          <li>Review the simulation options – defaults suit a typical rehearsal room.</li>
+          <li>Select the fingerings you care about most. The model only computes the notes you pick.</li>
+          <li>
+            Compare the charts and tables. Peaks in the impedance graph indicate strong resonances;
+            the intonation view reports how sharp or flat each note is.
+          </li>
+        </ol>
+      </Card>
       <Card
         title="Simulation options"
         action={
@@ -157,28 +172,36 @@ export function SimulationPage() {
           </div>
         }
       >
+        <p>
+          These controls mirror the settings a player might encounter. Small adjustments can help
+          you replicate concert hall conditions or outdoor performances.
+        </p>
         <div className="grid-two">
           <NumberField
             label="Temperature"
             value={simulationOptions.temp_C}
             unit="°C"
+            description="Warmer air lowers pitch slightly; colder air raises it."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, temp_C: value }))}
           />
           <NumberField
             label="Freq. min"
             value={simulationOptions.freq_min_hz}
             unit="Hz"
+            description="Lowest frequency to analyse. Keep it near the instrument's fundamental."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, freq_min_hz: value }))}
           />
           <NumberField
             label="Freq. max"
             value={simulationOptions.freq_max_hz}
             unit="Hz"
+            description="Highest frequency to include. Larger ranges take longer to compute."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, freq_max_hz: value }))}
           />
           <NumberField
             label="Points"
             value={simulationOptions.n_points}
+            description="How many samples to calculate between the min and max frequency."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, n_points: value }))}
           />
           <NumberField
@@ -186,6 +209,7 @@ export function SimulationPage() {
             value={simulationOptions.modes}
             step={1}
             min={1}
+            description="Number of acoustic modes to consider. Higher counts add detail."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, modes: Math.max(1, Math.round(value)) }))}
           />
           <NumberField
@@ -193,11 +217,13 @@ export function SimulationPage() {
             value={simulationOptions.concert_pitch_hz}
             unit="Hz"
             step={0.1}
+            description="Reference tuning (A4) used when calculating intonation offsets."
             onChange={(value) => setSimulationOptions((prev) => ({ ...prev, concert_pitch_hz: value }))}
           />
         </div>
         <label className="ow-select">
           <span>Transposition</span>
+          <p className="select-help">Match the written part to the sounding pitch of your instrument.</p>
           <select
             value={simulationOptions.transposition}
             onChange={(event) => setSimulationOptions((prev) => ({ ...prev, transposition: event.target.value }))}
@@ -228,6 +254,10 @@ export function SimulationPage() {
 
       </Card>
       <Card title="Fingerings">
+        <p>
+          Click the notes you would like to analyse. We preserve your selection order, so feel free
+          to focus on one register at a time.
+        </p>
         <div className="fingerings-grid">
           {DEFAULT_NOTES.map((note) => {
             const active = selectedNotes.includes(note);
@@ -254,12 +284,24 @@ export function SimulationPage() {
         </div>
       </Card>
       <Card title="Input impedance">
+        <p>
+          Peaks in this chart show where the instrument naturally resonates. Higher peaks generally
+          mean easier note production.
+        </p>
         <ChartImpedance data={impedanceData} />
       </Card>
       <Card title="Intonation offsets">
+        <p>
+          Each bar displays how far a note is from your chosen concert pitch. Positive values are
+          sharp, negative values are flat.
+        </p>
         <ChartIntonation data={intonationData} />
       </Card>
       <Card title="Intonation table">
+        <p>
+          Prefer raw numbers? This table mirrors the chart above and includes the resonance frequency
+          for each fingering.
+        </p>
         <Table columns={notesColumns} data={simulationResult?.intonation ?? []} />
       </Card>
     </div>

--- a/ui/src/styles/openwind.css
+++ b/ui/src/styles/openwind.css
@@ -93,6 +93,27 @@ main {
   padding: clamp(20px, 3vw, 32px);
 }
 
+.guidance-card {
+  border-left: 4px solid var(--accent);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(15, 23, 42, 0.6));
+}
+
+.guidance-card .ow-card-body {
+  gap: 12px;
+}
+
+.guidance-card ol,
+.guidance-card ul {
+  margin: 0;
+  padding-left: 1.4rem;
+  display: grid;
+  gap: 6px;
+}
+
+.guidance-card li {
+  line-height: 1.5;
+}
+
 .ow-card-header {
   display: flex;
   justify-content: space-between;
@@ -223,6 +244,12 @@ main {
 .ow-select span {
   font-weight: 600;
   color: var(--color-text-subtle);
+}
+
+.select-help {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .ow-select select {

--- a/ui/src/styles/openwind.css
+++ b/ui/src/styles/openwind.css
@@ -725,6 +725,21 @@ main {
   gap: 12px;
 }
 
+.export-notice {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.export-notice a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.export-notice a:hover,
+.export-notice a:focus-visible {
+  text-decoration: underline;
+}
+
 .log {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- add workspace state for recommendation preferences so the geometry page can send player profile, register focus, and tuning scale information to the OpenWInD APIs
- enable editing and reporting tone-hole undercut values across the geometry, home, and results views while surfacing direct download links for exported files
- sync the global A4 setting with recommendation defaults and update styles to present latest export status

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e39100d31c832ca38d959e94549f7c